### PR TITLE
feat: add intent filter for handling time/epoch data in calendar app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,6 +69,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!-- Handle time/epoch content URIs from CalendarContract (e.g. clock widget "Go to calendar") -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <data android:mimeType="time/epoch"/>
+                <data android:host="com.android.calendar"/>
+                <data android:scheme="content"/>
+            </intent-filter>
+
             <!-- Register as calendar app (for "Default calendar" picker and Android Auto) -->
             <intent-filter tools:ignore="AppLinkUrlError">
                 <action android:name="android.intent.action.VIEW" />


### PR DESCRIPTION
## Description

This PR adds an intent filter to handle time/epoch content URIs from CalendarContract. In practice, this would allow most app/widget linking to calendar using the current time to work (e.g. clock widget "Go to calendar").

## Related Issue

May fix #91 and #76 , but both should try in their scenario

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [X] My code follows the project's code style
- [X] I have tested my changes locally
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes (`./gradlew test`)
- [X] The app builds successfully (`./gradlew assembleDebug`)