### PR TITLE
English text change for when no events, less passive agressive

### DIFF
--- a/app/src/androidTest/kotlin/org/onekash/kashcal/ui/screens/HomeScreenComposeTest.kt
+++ b/app/src/androidTest/kotlin/org/onekash/kashcal/ui/screens/HomeScreenComposeTest.kt
@@ -551,7 +551,7 @@ class HomeScreenComposeTest {
 
         // Day pager shows multiple days, each with empty message - verify at least one exists
         // Using fetchSemanticsNodes for CI reliability (may be outside viewport on slow emulators)
-        assert(composeTestRule.onAllNodesWithText("Nothing to see here; go touch grass?")
+        assert(composeTestRule.onAllNodesWithText("No events")
             .fetchSemanticsNodes().isNotEmpty()) {
             "Expected empty day message to exist in semantic tree"
         }

--- a/app/src/main/res/values-en-rGB/strings.xml
+++ b/app/src/main/res/values-en-rGB/strings.xml
@@ -677,7 +677,7 @@
     <string name="recurring_this_event">This event</string>
     <string name="recurring_all_events">All events</string>
     <string name="empty_pick_a_day">Pick a day. Seize it.</string>
-    <string name="empty_no_events_day">Nothing to see here; go touch grass?</string>
+    <string name="empty_no_events_day">No events</string>
     <string name="filter_date">Date</string>
     <string name="label_select_date">Select a date</string>
     <string name="hint_tap_date_range">Tap same date for single day, or another date for range</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -907,7 +907,7 @@
     <!-- Empty state: playful/casual — shown when no day is selected. Keep the playful tone. -->
     <string name="empty_pick_a_day">Pick a day. Seize it.</string>
     <!-- Empty state: playful/casual — shown when selected day has no events. Keep informal. -->
-    <string name="empty_no_events_day">Nothing to see here; go touch grass?</string>
+    <string name="empty_no_events_day">No events</string>
     <!-- Search filter chip: filter by date (noun, not verb) -->
     <string name="filter_date">Date</string>
     <string name="label_select_date">Select a date</string>


### PR DESCRIPTION
## Description

Change English translation from "Nothing to see here; go touch grass?" to  No events". Less passive agressive

## Related Issue

N/A

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [ ] I have tested my changes locally
- [ ] New and existing unit tests pass locally (`./gradlew test`)
- [ ] The app builds successfully (`./gradlew assembleDebug`)

## AI Disclosure

If you used AI assistance (Copilot, ChatGPT, Claude, etc.) while working on this PR, please disclose it here. This helps reviewers calibrate their review.

- [x] No AI assistance was used
- [ ] AI assisted with: ___

## Screenshots (if applicable)

Add screenshots for UI changes.