### PR TITLE
Feature/month widget event titles

### DIFF
--- a/app/src/main/kotlin/org/onekash/kashcal/data/preferences/KashCalDataStore.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/data/preferences/KashCalDataStore.kt
@@ -478,6 +478,18 @@ class KashCalDataStore(
     }
 
     /**
+     * Whether the month widget renders event title rows in day cells (timed events as
+     * color stripe + title, all-day events as chips, mirroring the in-app month view)
+     * instead of the colored indicator dots. Default: false (dots).
+     */
+    val monthWidgetEventTitles: Flow<Boolean>
+        get() = getPreference(PreferencesKeys.MONTH_WIDGET_EVENT_TITLES, false)
+
+    suspend fun setMonthWidgetEventTitles(titles: Boolean) {
+        setPreference(PreferencesKeys.MONTH_WIDGET_EVENT_TITLES, titles)
+    }
+
+    /**
      * Last time-grid scroll position as minutes from midnight (0..1439).
      * -1 means never saved: fresh installs fall back to the default scroll hour.
      */

--- a/app/src/main/kotlin/org/onekash/kashcal/data/preferences/PreferencesKeys.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/data/preferences/PreferencesKeys.kt
@@ -149,6 +149,13 @@ object PreferencesKeys {
     val WIDGET_DETAILED_ROWS = booleanPreferencesKey("widget_detailed_rows")
 
     /**
+     * Month widget day-cell event style. false = colored indicator dots below the day
+     * number; true = event title rows (mirroring the in-app month view: timed events as
+     * color stripe + title, all-day events as filled/tinted chips). Default: false (dots).
+     */
+    val MONTH_WIDGET_EVENT_TITLES = booleanPreferencesKey("month_widget_event_titles")
+
+    /**
      * Last vertical scroll position of the Day/3-Day/Week time grid, stored as
      * minutes from midnight (0..1439). Restored on cold launch so the timeline
      * opens where the user last left it instead of the default hour. Stored as

--- a/app/src/main/kotlin/org/onekash/kashcal/domain/backup/ExportablePreferences.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/domain/backup/ExportablePreferences.kt
@@ -48,6 +48,7 @@ object ExportablePreferences {
         PreferencesKeys.DEFAULT_CALENDAR_VIEW.name to PrefKind.STRING,
         PreferencesKeys.WIDGET_MAX_EVENTS_PER_DAY.name to PrefKind.INT,
         PreferencesKeys.WIDGET_DETAILED_ROWS.name to PrefKind.BOOL,
+        PreferencesKeys.MONTH_WIDGET_EVENT_TITLES.name to PrefKind.BOOL,
         PreferencesKeys.CONTACT_BIRTHDAYS_ENABLED.name to PrefKind.BOOL,
         PreferencesKeys.BIRTHDAY_REMINDER.name to PrefKind.INT,
         PreferencesKeys.CONTACT_ANNIVERSARIES_ENABLED.name to PrefKind.BOOL,
@@ -104,6 +105,7 @@ object ExportablePreferences {
         PreferencesKeys.DEFAULT_CALENDAR_VIEW,
         PreferencesKeys.WIDGET_MAX_EVENTS_PER_DAY,
         PreferencesKeys.WIDGET_DETAILED_ROWS,
+        PreferencesKeys.MONTH_WIDGET_EVENT_TITLES,
         // Contact birthdays & anniversaries
         PreferencesKeys.CONTACT_BIRTHDAYS_ENABLED,
         PreferencesKeys.BIRTHDAY_REMINDER,

--- a/app/src/main/kotlin/org/onekash/kashcal/domain/backup/ExportablePreferences.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/domain/backup/ExportablePreferences.kt
@@ -124,8 +124,8 @@ object ExportablePreferences {
     ).also {
         // Bump this and the matching ExportablePreferencesTest assertion together
         // whenever a key is added to or removed from KEYS above.
-        require(it.size == 41) {
-            "KEYS size drifted; expected 41 allowed keys but got ${it.size}. Update ExportablePreferencesTest expectations too."
+        require(it.size == 42) {
+            "KEYS size drifted; expected 42 allowed keys but got ${it.size}. Update ExportablePreferencesTest expectations too."
         }
     }
 

--- a/app/src/main/kotlin/org/onekash/kashcal/ui/screens/AccountSettingsScreen.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/ui/screens/AccountSettingsScreen.kt
@@ -261,6 +261,8 @@ fun AccountSettingsScreen(
     onWidgetMaxEventsPerDayChange: (Int) -> Unit = {},
     widgetDetailedRows: Boolean = false,
     onWidgetDetailedRowsChange: (Boolean) -> Unit = {},
+    monthWidgetEventTitles: Boolean = false,
+    onMonthWidgetEventTitlesChange: (Boolean) -> Unit = {},
     // Version footer (Checkpoint 9)
     versionName: String = "",
     // Settings search
@@ -526,6 +528,22 @@ fun AccountSettingsScreen(
                                 checked = widgetDetailedRows,
                                 onCheckedChange = onWidgetDetailedRowsChange,
                                 info = detailedRowsInfo,
+                                showDivider = false,
+                                searchQuery = searchQuery
+                            )
+                        }
+
+                        val monthEventTitlesInfo = SettingsRowInfo(
+                            title = stringResource(R.string.settings_month_widget_event_titles),
+                            text = stringResource(R.string.settings_month_widget_event_titles_info)
+                        )
+                        row(label = stringResource(R.string.settings_month_widget_event_titles), id = "month-widget-event-titles") {
+                            SettingsToggleRow(
+                                icon = Icons.Default.CalendarMonth,
+                                label = stringResource(R.string.settings_month_widget_event_titles),
+                                checked = monthWidgetEventTitles,
+                                onCheckedChange = onMonthWidgetEventTitlesChange,
+                                info = monthEventTitlesInfo,
                                 showDivider = false,
                                 searchQuery = searchQuery
                             )

--- a/app/src/main/kotlin/org/onekash/kashcal/ui/screens/SettingsRoute.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/ui/screens/SettingsRoute.kt
@@ -144,6 +144,7 @@ fun SettingsRoute(
         val showWeekNumbers by viewModel.showWeekNumbers.collectAsStateWithLifecycle()
         val widgetMaxEventsPerDay by viewModel.widgetMaxEventsPerDay.collectAsStateWithLifecycle()
         val widgetDetailedRows by viewModel.widgetDetailedRows.collectAsStateWithLifecycle()
+        val monthWidgetEventTitles by viewModel.monthWidgetEventTitles.collectAsStateWithLifecycle()
         val syncLookbackDays by viewModel.syncLookbackDays.collectAsStateWithLifecycle()
         val isSearchActive by viewModel.isSearchActive.collectAsStateWithLifecycle()
         val searchQuery by viewModel.searchQuery.collectAsStateWithLifecycle()
@@ -775,6 +776,8 @@ fun SettingsRoute(
                             onWidgetMaxEventsPerDayChange = viewModel::setWidgetMaxEventsPerDay,
                             widgetDetailedRows = widgetDetailedRows,
                             onWidgetDetailedRowsChange = viewModel::setWidgetDetailedRows,
+                            monthWidgetEventTitles = monthWidgetEventTitles,
+                            onMonthWidgetEventTitlesChange = viewModel::setMonthWidgetEventTitles,
                             // Version footer
                             versionName = BuildConfig.VERSION_NAME,
                             // Navigate to Accounts detail screen

--- a/app/src/main/kotlin/org/onekash/kashcal/ui/viewmodels/AccountSettingsViewModel.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/ui/viewmodels/AccountSettingsViewModel.kt
@@ -381,6 +381,9 @@ class AccountSettingsViewModel @Inject constructor(
     private val _widgetDetailedRows = MutableStateFlow(false)
     val widgetDetailedRows: StateFlow<Boolean> = _widgetDetailedRows.asStateFlow()
 
+    private val _monthWidgetEventTitles = MutableStateFlow(false)
+    val monthWidgetEventTitles: StateFlow<Boolean> = _monthWidgetEventTitles.asStateFlow()
+
     // Backup & Restore dialog state
     private val _backupRestoreState = MutableStateFlow<BackupRestoreUiState>(BackupRestoreUiState.Idle)
     val backupRestoreState: StateFlow<BackupRestoreUiState> = _backupRestoreState.asStateFlow()
@@ -723,6 +726,11 @@ class AccountSettingsViewModel @Inject constructor(
             }
         }
         viewModelScope.launch {
+            dataStore.monthWidgetEventTitles.collect { titles ->
+                _monthWidgetEventTitles.value = titles
+            }
+        }
+        viewModelScope.launch {
             dataStore.syncPastDays.collect { days ->
                 _syncLookbackDays.value = days
             }
@@ -833,6 +841,17 @@ class AccountSettingsViewModel @Inject constructor(
         viewModelScope.launch {
             dataStore.setWidgetDetailedRows(detailed)
             widgetUpdateManager.updateAllWidgets("widget_detailed_rows_changed")
+        }
+    }
+
+    /**
+     * Update the month-widget day-cell style preference (indicator dots vs event title rows).
+     * Also triggers widget refresh since it changes how the month grid renders.
+     */
+    fun setMonthWidgetEventTitles(titles: Boolean) {
+        viewModelScope.launch {
+            dataStore.setMonthWidgetEventTitles(titles)
+            widgetUpdateManager.updateAllWidgets("month_widget_event_titles_changed")
         }
     }
 

--- a/app/src/main/kotlin/org/onekash/kashcal/widget/MonthWidget.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/widget/MonthWidget.kt
@@ -22,10 +22,12 @@ import org.onekash.kashcal.ui.model.MonthGrid
 import java.time.YearMonth
 
 /**
- * Month View widget showing a full month calendar grid with event indicator dots.
+ * Month View widget showing a full month calendar grid.
  *
  * Features:
- * - 6x7 calendar grid with day numbers and event indicator dots
+ * - 6x7 calendar grid with day numbers; events show as colored indicator dots by default,
+ *   or as event title rows when the "month widget event titles" setting is on — then with
+ *   continuous bars for multi-day events, mirroring the in-app month view
  * - Today highlighted with accent color
  * - Past days dimmed
  * - Tap day → navigate to that day in app
@@ -74,6 +76,7 @@ class MonthWidget : GlanceAppWidget() {
         val dataStore = KashCalDataStore(context)
         val initialFirstDayOfWeek = dataStore.getFirstDayOfWeek()
         val initialShowWeekNumbers = dataStore.showWeekNumbers.first()
+        val initialShowEventTitles = dataStore.monthWidgetEventTitles.first()
         // Resolve the accent BEFORE provideContent so the very first RemoteViews already carry the
         // picked seed. Seeding produceState with null would render one frame on the platform dynamic
         // palette (null ?: GlanceTheme.colors) and only swap to the seed on a later push — which, if
@@ -98,6 +101,11 @@ class MonthWidget : GlanceAppWidget() {
             }
             val showWeekNumbers by produceState(initialValue = initialShowWeekNumbers, key1 = refreshStamp) {
                 value = dataStore.showWeekNumbers.first()
+            }
+            // Same reactive pattern as showWeekNumbers: toggling the titles setting bumps the
+            // refresh stamp via WidgetUpdateManager, recomposing with the new day-cell style.
+            val showEventTitles by produceState(initialValue = initialShowEventTitles, key1 = refreshStamp) {
+                value = dataStore.monthWidgetEventTitles.first()
             }
 
             // Compute target month and grid (pure computation, no suspend needed)
@@ -132,6 +140,7 @@ class MonthWidget : GlanceAppWidget() {
                     targetMonth0 = targetMonth.monthValue - 1,
                     firstDayOfWeek = firstDayOfWeek,
                     showWeekNumbers = showWeekNumbers,
+                    showEventTitles = showEventTitles,
                     forcedDark = colorConfig.forcedDark
                 )
             }

--- a/app/src/main/kotlin/org/onekash/kashcal/widget/MonthWidgetContent.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/widget/MonthWidgetContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.unit.dp
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.LocalContext
+import androidx.glance.LocalSize
 import androidx.glance.action.ActionParameters
 import androidx.glance.action.actionParametersOf
 import androidx.glance.action.actionStartActivity
@@ -40,6 +41,7 @@ import androidx.glance.text.TextStyle
 import org.onekash.kashcal.MainActivity
 import org.onekash.kashcal.R
 import org.onekash.kashcal.ui.model.MonthGrid
+import org.onekash.kashcal.ui.shared.contrastForegroundOn
 import org.onekash.kashcal.util.DateTimeUtils
 import java.time.LocalDate
 import java.time.Month
@@ -92,6 +94,79 @@ internal const val MONTH_GRID_WEEK_ROWS = 6
  */
 internal const val WEEK_NUMBER_GUTTER_WIDTH_DP = 18
 
+// ==================== Event-title rows (optional month day-cell style) ====================
+
+/**
+ * Vertical space the month-widget header occupies, in dp. The nav-arrow / "+" boxes are
+ * 48dp touch targets, but the header's visual row is shorter; for sizing event-title rows
+ * we budget the visual row, not the touch target, so the grid doesn't under-fill.
+ */
+internal const val MONTH_HEADER_HEIGHT_DP = 40
+
+/**
+ * Vertical space the day-of-week letter row occupies, in dp: [WidgetTypography.monthDayNumber]
+ * (16sp ≈ 21dp at font-scale 1.0) plus the row's vertical padding.
+ */
+internal const val MONTH_DOW_ROW_HEIGHT_DP = 23
+
+/**
+ * Vertical space the day-number block reserves at the top of a day cell, in dp — the 16sp
+ * number plus the today marker's vertical padding.
+ */
+internal const val DAY_NUMBER_BLOCK_HEIGHT_DP = 18
+
+/** Height of one all-day event chip in a day cell, in dp (11sp label + breathing room). */
+internal const val EVENT_CHIP_HEIGHT_DP = 13
+
+/**
+ * Height of one event title row in a day cell, in dp. Sized to the chip, not to a timed
+ * row's theoretical line height: at 11sp the single-line title fits a 14dp slot, and the
+ * 3dp timed stripe centers within it. Budgeting 16dp here cost the standard-size widget
+ * its second title row (304dp height → 46dp cell → only one row), hiding "+n" markers.
+ */
+internal const val TIMED_TITLE_ROW_HEIGHT_DP = 13
+
+/** Vertical gap between two event rows in a day cell, in dp. */
+internal const val EVENT_ROW_GAP_DP = 1
+
+/**
+ * Hard cap on event slot rows per week in titles mode. The row budget itself comes from
+ * the actual cell height (grow the widget, get more rows); this cap only guards the
+ * RemoteViews transaction size — every slot row costs views in every day column, and an
+ * oversized widget bundle is dropped by the launcher, freezing the widget frame.
+ */
+internal const val MAX_EVENT_ROWS = 6
+
+/** Tint alpha for a timed multi-day span bar's background (in-app TimedSpan style). */
+internal const val TIMED_SPAN_TINT_ALPHA = 0.18f
+
+/**
+ * Tint alpha for an all-day FREE event chip's background, mirroring the in-app month view's
+ * AllDayFree style (same hue as the event, quiet enough to read as "not busy").
+ */
+internal const val ALL_DAY_FREE_TINT_ALPHA = 0.15f
+
+/** Width of the color stripe leading a timed-event title row, in dp (in-app Stripe style). */
+internal const val TIMED_STRIPE_WIDTH_DP = 3
+
+/** Corner radius of all-day event chips and the timed stripe, in dp. */
+internal const val EVENT_CHIP_CORNER_RADIUS_DP = 3
+
+/**
+ * Horizontal chrome around the title text inside a day cell, in dp: chip padding (3dp) or
+ * stripe + gap (3+2dp) on the left, ~3dp on the right. Subtracted from the cell width before
+ * estimating how many title characters fit.
+ */
+internal const val EVENT_ROW_TEXT_CHROME_DP = 8
+
+/**
+ * Estimated average advance width per character at [WidgetTypography.label] (11sp) and
+ * font-scale 1.0, in dp. Used to pre-truncate titles with an ellipsis because Glance's Text
+ * clips overflow mid-glyph instead of ellipsizing. Slightly generous on purpose: a touch too
+ * short beats a clipped glyph.
+ */
+internal const val TITLE_CHAR_WIDTH_DP = 6
+
 /**
  * The weeks the widget should actually render: [MonthGrid.compute] always returns 6 rows (fixed
  * for the full-size view's paging), but a month usually spans 5 (sometimes 4 or 6). Drop trailing
@@ -136,6 +211,8 @@ internal fun formatMonthHeader(
  * @param targetMonth0 0-indexed month of the displayed month
  * @param firstDayOfWeek java.util.Calendar constant for first day of week
  * @param showWeekNumbers whether to render the leading week-of-year gutter column
+ * @param showEventTitles whether day cells render event title rows (mirroring the in-app
+ *   month view) instead of the colored indicator dots
  * @param forcedDark the widget's light/dark pin (null = follow system) — used for the static
  *   adjacent-month text color, which lives outside the Glance scheme and can't see a pinned face
  */
@@ -148,6 +225,7 @@ fun MonthWidgetContent(
     targetMonth0: Int,
     firstDayOfWeek: Int,
     showWeekNumbers: Boolean = false,
+    showEventTitles: Boolean = false,
     forcedDark: Boolean? = null
 ) {
     val headerText = formatMonthHeader(targetYear, targetMonth0)
@@ -173,31 +251,350 @@ fun MonthWidgetContent(
         // how many weeks the month spans — consistent look at any widget size, no dead space.
         val weeks = visibleWeeks(monthGrid)
         val gutterLabels = weekNumberGutterLabels(monthGrid, showWeekNumbers)
-        weeks.forEachIndexed { weekIndex, week ->
-            Row(
-                modifier = GlanceModifier.fillMaxWidth().defaultWeight(),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                if (showWeekNumbers) {
-                    WeekNumberGutterCell(gutterLabels[weekIndex])
-                }
-                week.forEach { cell ->
-                    val dayCode = MonthGrid.computeDayCodeForCell(cell, targetYear, targetMonth0)
-                    val events = monthEvents[dayCode].orEmpty()
-                    val isToday = dayCode == todayDayCode
-                    val isPast = dayCode < todayDayCode
 
-                    DayCell(
+        // Titles mode sizes its rows from the ACTUAL widget size (SizeMode.Exact) because the
+        // week rows stretch via defaultWeight: how many title rows a cell can show and how many
+        // title characters fit depend on the stretched cell height/width, which only LocalSize
+        // knows. Dots mode needs none of this — a dot row fits any cell that fits the number.
+        val widgetSize = LocalSize.current
+        val cellHeightDp = (widgetSize.height.value - MONTH_HEADER_HEIGHT_DP - MONTH_DOW_ROW_HEIGHT_DP) / weeks.size
+        val cellWidthDp = (widgetSize.width.value - gridHorizontalPaddingDp(showWeekNumbers)) / 7f
+        val eventRowCount = if (showEventTitles) maxEventRows(cellHeightDp) else 0
+        val titleChars = if (showEventTitles) maxTitleChars(cellWidthDp) else 0
+
+        weeks.forEachIndexed { weekIndex, week ->
+            if (showEventTitles && eventRowCount > 0) {
+                // Titles mode: week slot layout — multi-day events span their columns as
+                // continuous bars, single-day events fill the remaining per-cell slots.
+                val weekDayCodes = week.map { MonthGrid.computeDayCodeForCell(it, targetYear, targetMonth0) }
+                // Sanity: a week row is always 7 strictly-increasing day codes. If that
+                // ever breaks (grid/cell mismatch), fall back to dots rather than render
+                // bars anchored on wrong columns.
+                check(weekDayCodes.size == 7 && weekDayCodes.zipWithNext().all { (a, b) -> b > a }) {
+                    "week day codes not strictly increasing: $weekDayCodes"
+                }
+                val weekRender = computeMonthWidgetWeekRender(weekDayCodes, monthEvents, eventRowCount)
+                TitlesWeekRow(
+                    // The weight comes from the caller: defaultWeight() only resolves inside
+                    // the parent Column's scope, not at this function's own top level.
+                    modifier = GlanceModifier.fillMaxWidth().defaultWeight(),
+                    week = week,
+                    weekDayCodes = weekDayCodes,
+                    weekRender = weekRender,
+                    todayDayCode = todayDayCode,
+                    monthEvents = monthEvents,
+                    cellWidthDp = cellWidthDp,
+                    maxTitleChars = titleChars,
+                    gutterLabel = if (showWeekNumbers) gutterLabels[weekIndex] else null,
+                    forcedDark = forcedDark
+                )
+            } else {
+                Row(
+                    modifier = GlanceModifier.fillMaxWidth().defaultWeight(),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    if (showWeekNumbers) {
+                        WeekNumberGutterCell(gutterLabels[weekIndex])
+                    }
+                    week.forEach { cell ->
+                        val dayCode = MonthGrid.computeDayCodeForCell(cell, targetYear, targetMonth0)
+                        val events = monthEvents[dayCode].orEmpty()
+                        val isToday = dayCode == todayDayCode
+                        val isPast = dayCode < todayDayCode
+
+                        DayCell(
+                            modifier = GlanceModifier.defaultWeight(),
+                            cell = cell,
+                            dayCode = dayCode,
+                            events = events,
+                            isToday = isToday,
+                            isPast = isPast,
+                            forcedDark = forcedDark
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * One week in titles mode: a day-number row (same treatment as the dots-mode cells, minus
+ * the dots), then the week's slot rows — spanning bars for multi-day events, snippets for
+ * single-day events, "+n" overflow markers where a cell's events did not fit.
+ */
+@Composable
+private fun TitlesWeekRow(
+    modifier: GlanceModifier,
+    week: List<MonthGrid.DayCell>,
+    weekDayCodes: List<Int>,
+    weekRender: MonthWidgetWeekRender,
+    todayDayCode: Int,
+    monthEvents: Map<Int, List<WidgetDataRepository.WidgetEvent>>,
+    cellWidthDp: Float,
+    maxTitleChars: Int,
+    gutterLabel: String?,
+    forcedDark: Boolean?
+) {
+    Row(modifier = modifier) {
+        if (gutterLabel != null) {
+            WeekNumberGutterCell(gutterLabel)
+        }
+        Column(modifier = GlanceModifier.defaultWeight().fillMaxHeight()) {
+            // Day-number row, identical in look to the dots-mode cells.
+            Row(modifier = GlanceModifier.fillMaxWidth()) {
+                week.forEachIndexed { col, cell ->
+                    val dayCode = weekDayCodes[col]
+                    DayNumberCell(
                         modifier = GlanceModifier.defaultWeight(),
                         cell = cell,
                         dayCode = dayCode,
-                        events = events,
-                        isToday = isToday,
-                        isPast = isPast,
+                        isToday = dayCode == todayDayCode,
+                        isPast = dayCode < todayDayCode,
+                        eventCount = monthEvents[dayCode].orEmpty().size,
                         forcedDark = forcedDark
                     )
                 }
             }
+            // Slot rows (bars + snippets + overflow). Only as many rows as fit the cell
+            // height were computed, so nothing clips off the week row's bottom.
+            weekRender.slots.forEach { slotRow ->
+                SlotRow(
+                    slotRow = slotRow,
+                    weekDayCodes = weekDayCodes,
+                    cellWidthDp = cellWidthDp,
+                    maxTitleChars = maxTitleChars
+                )
+            }
+        }
+    }
+}
+
+/**
+ * The day-number cell of a titles-mode week row: centered number with the today marker and
+ * past/adjacent-month dimming, tappable to open the day — the dots-mode cell minus the dots.
+ */
+@Composable
+private fun DayNumberCell(
+    modifier: GlanceModifier,
+    cell: MonthGrid.DayCell,
+    dayCode: Int,
+    isToday: Boolean,
+    isPast: Boolean,
+    eventCount: Int,
+    forcedDark: Boolean?
+) {
+    val isAdjacentMonth = cell.position != MonthGrid.DayPosition.MonthDate
+    val accessibilityDesc = buildAccessibilityDescription(
+        LocalContext.current.resources, dayCode, if (isAdjacentMonth) 0 else eventCount
+    )
+    val textColor = when {
+        isAdjacentMonth -> WidgetTheme.adjacentMonthText(forcedDark)
+        isToday -> WidgetTheme.onTodayMarker
+        isPast -> WidgetTheme.pastEventText
+        else -> WidgetTheme.primaryText
+    }
+    Box(
+        modifier = modifier
+            .clickable(dayClickAction(dayCode))
+            .semantics { contentDescription = accessibilityDesc },
+        contentAlignment = Alignment.Center
+    ) {
+        Box(
+            modifier = if (isToday && !isAdjacentMonth) {
+                GlanceModifier
+                    .cornerRadius(TODAY_MARKER_CORNER_RADIUS_DP.dp)
+                    .background(WidgetTheme.todayMarkerBackground)
+                    .padding(
+                        horizontal = TODAY_MARKER_HORIZONTAL_PADDING_DP.dp,
+                        vertical = TODAY_MARKER_VERTICAL_PADDING_DP.dp
+                    )
+            } else {
+                GlanceModifier
+            },
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "${cell.dayOfMonth}",
+                style = TextStyle(
+                    color = textColor,
+                    fontSize = WidgetTypography.monthDayNumber,
+                    fontWeight = if (isToday && !isAdjacentMonth) FontWeight.Bold else FontWeight.Medium
+                )
+            )
+        }
+    }
+}
+
+/** Tap action shared by every day-cell surface: open the app at that day. */
+private fun dayClickAction(dayCode: Int) = actionStartActivity<MainActivity>(
+    parameters = actionParametersOf(
+        ActionParameters.Key<String>(EXTRA_ACTION) to ACTION_GO_TO_DATE,
+        ActionParameters.Key<Int>(EXTRA_DAY_CODE) to dayCode
+    )
+)
+
+/**
+ * One slot row of a titles-mode week: consecutive [MonthWidgetSlot.BarSegment]s of the same
+ * span merge into one continuous bar across their columns; single-day snippets, overflow
+ * markers, and empty cells take one column each.
+ */
+@Composable
+private fun SlotRow(
+    slotRow: List<MonthWidgetSlot>,
+    weekDayCodes: List<Int>,
+    cellWidthDp: Float,
+    maxTitleChars: Int
+) {
+    Row(modifier = GlanceModifier.fillMaxWidth().padding(top = EVENT_ROW_GAP_DP.dp)) {
+        var col = 0
+        while (col < 7) {
+            // The last item in the row stretches to fill whatever rounding the fixed cell
+            // widths left over, so the 7 columns always span the full grid width exactly.
+            val isLastItem = run {
+                var next = col + 1
+                if (slotRow[col] is MonthWidgetSlot.BarSegment) {
+                    val span = (slotRow[col] as MonthWidgetSlot.BarSegment).span
+                    while (next < 7 && (slotRow[next] as? MonthWidgetSlot.BarSegment)?.span == span) next++
+                }
+                next >= 7
+            }
+            val cellModifier = if (isLastItem) {
+                GlanceModifier.defaultWeight()
+            } else {
+                GlanceModifier.width(cellWidthDp.dp)
+            }
+            when (val content = slotRow[col]) {
+                is MonthWidgetSlot.BarSegment -> {
+                    // Merge the whole run of this span's segments into one bar.
+                    var endCol = col
+                    while (endCol + 1 < 7 &&
+                        (slotRow[endCol + 1] as? MonthWidgetSlot.BarSegment)?.span == content.span
+                    ) {
+                        endCol++
+                    }
+                    val width = endCol - col + 1
+                    SpanBar(
+                        span = content.span,
+                        width = width,
+                        maxTitleChars = maxTitleChars,
+                        dayCode = weekDayCodes[col],
+                        // Fixed width, not defaultWeight(): Glance's defaultWeight() is always
+                        // weight(1f) — there is no weight(n) — so a weighted bar collapses to a
+                        // single column no matter how many days it spans. The widget knows the
+                        // real cell width from LocalSize, so the bar takes width × cellWidth.
+                        modifier = if (isLastItem) cellModifier else GlanceModifier.width((cellWidthDp * width).dp)
+                    )
+                    col = endCol + 1
+                }
+                is MonthWidgetSlot.CellEvent -> {
+                    Box(modifier = cellModifier) {
+                        EventTitleRow(content.event, maxTitleChars)
+                    }
+                    col++
+                }
+                is MonthWidgetSlot.Overflow -> {
+                    Box(modifier = cellModifier) {
+                        Text(
+                            text = LocalContext.current.getString(R.string.status_more_events, content.count),
+                            style = TextStyle(
+                                color = WidgetTheme.secondaryText,
+                                fontSize = WidgetTypography.label
+                            ),
+                            maxLines = 1,
+                            modifier = GlanceModifier.padding(start = 3.dp)
+                        )
+                    }
+                    col++
+                }
+                MonthWidgetSlot.Empty -> {
+                    // Transparent tap surface so empty parts of a day column still open the day.
+                    Box(
+                        modifier = cellModifier
+                            .clickable(dayClickAction(weekDayCodes[col]))
+                    ) {}
+                    col++
+                }
+            }
+        }
+    }
+}
+
+/**
+ * A multi-day event's continuous bar across [width] day columns, styled like the in-app
+ * month view's spans: all-day busy = solid fill with contrasting title, all-day free =
+ * quiet tint with colored title, timed multi-day = tint with a leading color stripe.
+ * The title shows only at the bar's first segment of this week row; continuation segments
+ * (flush edges) keep the bar bare, like the app's flush span caps.
+ */
+@Composable
+private fun SpanBar(
+    span: MonthWidgetSpan,
+    width: Int,
+    maxTitleChars: Int,
+    dayCode: Int,
+    modifier: GlanceModifier
+) {
+    val event = span.event
+    val color = Color(event.calendarColor)
+    // The title only fits across the bar's full span, so it earns roughly `width` times the
+    // per-cell character budget (minus the chrome the single-cell rows already deduct).
+    val spanChars = (maxTitleChars * width).coerceAtLeast(maxTitleChars)
+    val title = ellipsizeTitle(event.title, spanChars)
+
+    // Corner radius per edge: flush (continuing) edges stay square so the bar reads as one
+    // unbroken band across week boundaries; capped edges round off.
+    val capRadius = EVENT_CHIP_CORNER_RADIUS_DP.dp
+
+    val isTimed = !event.isAllDay
+    val fill = when {
+        isTimed -> color.copy(alpha = TIMED_SPAN_TINT_ALPHA)
+        event.isFree -> color.copy(alpha = ALL_DAY_FREE_TINT_ALPHA)
+        else -> color
+    }
+    // Timed spans tint the surface only slightly, so the title keeps the cell's text color
+    // (like the in-app TimedSpan); all-day chips carry their own contrast logic.
+    val textProvider = when {
+        isTimed -> WidgetTheme.primaryText
+        event.isFree -> ColorProvider(day = color, night = color)
+        else -> ColorProvider(day = contrastForegroundOn(color), night = contrastForegroundOn(color))
+    }
+
+    // Corner radii per edge via two nested boxes is not possible in Glance — the modifier
+    // applies one radius to all corners. The bar therefore uses the full radius when both
+    // ends cap here, and none while either edge continues into an adjacent week.
+    val radiusModifier = if (!span.leftFlush && !span.rightFlush) {
+        GlanceModifier.cornerRadius(capRadius)
+    } else {
+        GlanceModifier
+    }
+
+    Row(
+        modifier = modifier
+            .height(EVENT_CHIP_HEIGHT_DP.dp)
+            .then(radiusModifier)
+            .background(ColorProvider(day = fill, night = fill))
+            .clickable(dayClickAction(dayCode)),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (isTimed && !span.leftFlush) {
+            Box(
+                modifier = GlanceModifier
+                    .width(TIMED_STRIPE_WIDTH_DP.dp)
+                    .fillMaxHeight()
+                    .background(ColorProvider(day = color, night = color))
+            ) {}
+        }
+        if (!span.leftFlush) {
+            Text(
+                text = title,
+                style = TextStyle(
+                    color = textProvider,
+                    fontSize = WidgetTypography.label
+                ),
+                maxLines = 1,
+                modifier = GlanceModifier.padding(horizontal = 3.dp)
+            )
         }
     }
 }
@@ -357,7 +754,9 @@ private fun WeekNumberGutterCell(label: String) {
 }
 
 /**
- * Single day cell showing day number and up to 3 colored event indicator dots.
+ * Single day cell in dots mode: centered day number (with today marker) plus up to 3
+ * colored event indicator dots. Titles mode renders week-based slot rows instead — see
+ * [TitlesWeekRow] — and never reaches this composable.
  */
 @Composable
 private fun DayCell(
@@ -373,91 +772,67 @@ private fun DayCell(
     val resources = LocalContext.current.resources
     val accessibilityDesc = buildAccessibilityDescription(resources, dayCode, if (isAdjacentMonth) 0 else events.size)
 
-    // Adjacent-month cells: faded day number, tappable, no dots or today highlight
-    if (isAdjacentMonth) {
-        Box(
-            modifier = modifier
-                .fillMaxHeight()
-                .clickable(
-                    actionStartActivity<MainActivity>(
-                        parameters = actionParametersOf(
-                            ActionParameters.Key<String>(EXTRA_ACTION) to ACTION_GO_TO_DATE,
-                            ActionParameters.Key<Int>(EXTRA_DAY_CODE) to dayCode
-                        )
-                    )
-                )
-                .semantics { contentDescription = accessibilityDesc },
-            contentAlignment = Alignment.TopCenter
-        ) {
-            Text(
-                text = "${cell.dayOfMonth}",
-                style = TextStyle(
-                    color = WidgetTheme.adjacentMonthText(forcedDark),
-                    fontSize = WidgetTypography.monthDayNumber
-                )
-            )
-        }
-        return
-    }
-
     val dotColors = extractDotColors(events)
 
     Box(
         modifier = modifier
             .fillMaxHeight()
-            .clickable(
-                actionStartActivity<MainActivity>(
-                    parameters = actionParametersOf(
-                        ActionParameters.Key<String>(EXTRA_ACTION) to ACTION_GO_TO_DATE,
-                        ActionParameters.Key<Int>(EXTRA_DAY_CODE) to dayCode
-                    )
-                )
-            )
+            .clickable(dayClickAction(dayCode))
             .semantics { contentDescription = accessibilityDesc },
         contentAlignment = Alignment.TopCenter
     ) {
         Column(
-            horizontalAlignment = Alignment.CenterHorizontally
+            modifier = GlanceModifier.fillMaxWidth()
         ) {
-            // Day number. Today is marked with a solid accent circle around the
-            // number (the number flips to the on-accent color) — the Material /
-            // Google Calendar "today" treatment; other days show a bare number.
+            // Day number, centered. Today is marked with a solid accent circle around the
+            // number (the number flips to the on-accent color) — the Material / Google
+            // Calendar "today" treatment; other days show a bare number.
             val textColor = when {
+                isAdjacentMonth -> WidgetTheme.adjacentMonthText(forcedDark)
                 isToday -> WidgetTheme.onTodayMarker
                 isPast -> WidgetTheme.pastEventText
                 else -> WidgetTheme.primaryText
             }
             Box(
-                modifier = if (isToday) {
-                    GlanceModifier
-                        .cornerRadius(TODAY_MARKER_CORNER_RADIUS_DP.dp)
-                        .background(WidgetTheme.todayMarkerBackground)
-                        .padding(
-                            horizontal = TODAY_MARKER_HORIZONTAL_PADDING_DP.dp,
-                            vertical = TODAY_MARKER_VERTICAL_PADDING_DP.dp
-                        )
-                } else {
-                    GlanceModifier
-                },
+                modifier = GlanceModifier.fillMaxWidth(),
                 contentAlignment = Alignment.Center
             ) {
-                Text(
-                    text = "${cell.dayOfMonth}",
-                    style = TextStyle(
-                        color = textColor,
-                        fontSize = WidgetTypography.monthDayNumber,
-                        // Medium (vs Normal) gives the numbers more presence against
-                        // the dynamic Material You surface, which renders softer than
-                        // a fixed high-contrast palette. Today stays Bold.
-                        fontWeight = if (isToday) FontWeight.Bold else FontWeight.Medium
+                Box(
+                    modifier = if (isToday && !isAdjacentMonth) {
+                        GlanceModifier
+                            .cornerRadius(TODAY_MARKER_CORNER_RADIUS_DP.dp)
+                            .background(WidgetTheme.todayMarkerBackground)
+                            .padding(
+                                horizontal = TODAY_MARKER_HORIZONTAL_PADDING_DP.dp,
+                                vertical = TODAY_MARKER_VERTICAL_PADDING_DP.dp
+                            )
+                    } else {
+                        GlanceModifier
+                    },
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(
+                        text = "${cell.dayOfMonth}",
+                        style = TextStyle(
+                            color = textColor,
+                            fontSize = WidgetTypography.monthDayNumber,
+                            // Medium (vs Normal) gives the numbers more presence against
+                            // the dynamic Material You surface, which renders softer than
+                            // a fixed high-contrast palette. Today stays Bold.
+                            fontWeight = if (isToday && !isAdjacentMonth) FontWeight.Bold else FontWeight.Medium
+                        )
                     )
-                )
+                }
             }
 
-            // Event indicator dots (up to 3)
-            if (dotColors.isNotEmpty()) {
+            // Adjacent-month cells stay bare — a faded number only.
+            if (!isAdjacentMonth && dotColors.isNotEmpty()) {
+                // Event indicator dots (up to 3)
                 Spacer(modifier = GlanceModifier.height(1.dp))
-                Row(horizontalAlignment = Alignment.CenterHorizontally) {
+                Row(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = GlanceModifier.fillMaxWidth()
+                ) {
                     dotColors.forEachIndexed { index, color ->
                         if (index > 0) {
                             Spacer(modifier = GlanceModifier.width(2.dp))
@@ -471,6 +846,66 @@ private fun DayCell(
                     }
                 }
             }
+        }
+    }
+}
+
+/**
+ * One event row inside a day cell in titles mode, mirroring the in-app month view's
+ * snippet styles ([org.onekash.kashcal.ui.screens.monthfull.snippetStyleFor]):
+ * - timed event: leading 3dp color stripe + title in the cell's text color
+ * - all-day busy: filled chip in the event color + WCAG-contrasting title
+ * - all-day free: quiet tinted chip + title in the event color
+ */
+@Composable
+private fun EventTitleRow(
+    event: WidgetDataRepository.WidgetEvent,
+    maxTitleChars: Int
+) {
+    val color = Color(event.calendarColor)
+    val title = ellipsizeTitle(event.title, maxTitleChars)
+    if (!event.isAllDay) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = GlanceModifier.fillMaxWidth().height(TIMED_TITLE_ROW_HEIGHT_DP.dp)
+        ) {
+            Box(
+                modifier = GlanceModifier
+                    .width(TIMED_STRIPE_WIDTH_DP.dp)
+                    .height(EVENT_CHIP_HEIGHT_DP.dp)
+                    .cornerRadius(1.dp)
+                    .background(ColorProvider(day = color, night = color))
+            ) {}
+            Spacer(modifier = GlanceModifier.width(2.dp))
+            Text(
+                text = title,
+                style = TextStyle(
+                    color = WidgetTheme.primaryText,
+                    fontSize = WidgetTypography.label
+                ),
+                maxLines = 1
+            )
+        }
+    } else {
+        val fill = if (event.isFree) color.copy(alpha = ALL_DAY_FREE_TINT_ALPHA) else color
+        val textColor = if (event.isFree) color else contrastForegroundOn(color)
+        Box(
+            modifier = GlanceModifier
+                .fillMaxWidth()
+                .height(EVENT_CHIP_HEIGHT_DP.dp)
+                .cornerRadius(EVENT_CHIP_CORNER_RADIUS_DP.dp)
+                .background(ColorProvider(day = fill, night = fill)),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            Text(
+                text = title,
+                style = TextStyle(
+                    color = ColorProvider(day = textColor, night = textColor),
+                    fontSize = WidgetTypography.label
+                ),
+                maxLines = 1,
+                modifier = GlanceModifier.padding(horizontal = 3.dp)
+            )
         }
     }
 }
@@ -549,6 +984,51 @@ internal fun extractDotColors(
         .map { it.calendarColor }
         .distinct()
         .take(maxDots)
+}
+
+/**
+ * Horizontal padding the month grid keeps on each side (the day-of-week header row pads by
+ * 2dp on both ends; the week-number gutter takes its fixed width off the grid). Subtracted
+ * from the widget width before dividing into the 7 day columns.
+ */
+internal fun gridHorizontalPaddingDp(showWeekNumbers: Boolean): Int =
+    (if (showWeekNumbers) WEEK_NUMBER_GUTTER_WIDTH_DP else 0) + 4
+
+/**
+ * How many event slot rows fit a week row of [cellHeightDp] below the day-number block —
+ * the budget the titles mode fills (grow the widget, get more rows), capped only by
+ * [MAX_EVENT_ROWS]. A row costs [TIMED_TITLE_ROW_HEIGHT_DP] plus one [EVENT_ROW_GAP_DP] per
+ * stacked row. Returns 0 when not even one row fits — the caller then falls back to dots.
+ */
+internal fun maxEventRows(cellHeightDp: Float): Int {
+    // A day cell holds the day-number block plus as many event rows as fit. Each row costs
+    // its height; rows after the first also pay the inter-row gap. The standard-size widget
+    // (304dp, 5 weeks → ~48dp cell) must reach 2 rows so a "+n" marker can share a cell
+    // with one visible title instead of going blank.
+    val usable = cellHeightDp - DAY_NUMBER_BLOCK_HEIGHT_DP
+    if (usable < TIMED_TITLE_ROW_HEIGHT_DP) return 0
+    val rows = 1 + ((usable - TIMED_TITLE_ROW_HEIGHT_DP) / (TIMED_TITLE_ROW_HEIGHT_DP + EVENT_ROW_GAP_DP)).toInt()
+    return rows.coerceAtMost(MAX_EVENT_ROWS)
+}
+
+/**
+ * How many title characters fit a day cell of [cellWidthDp] after the row chrome (stripe or
+ * chip padding), at [TITLE_CHAR_WIDTH_DP] per character. Minimum 4 so an ellipsis still
+ * leaves something readable.
+ */
+internal fun maxTitleChars(cellWidthDp: Float): Int =
+    ((cellWidthDp - EVENT_ROW_TEXT_CHROME_DP) / TITLE_CHAR_WIDTH_DP)
+        .toInt()
+        .coerceAtLeast(4)
+
+/**
+ * Truncate [title] to [maxChars] with a trailing ellipsis. Glance's Text clips overflow
+ * mid-glyph rather than ellipsizing, so titles are pre-shortened; [maxTitleChars] estimates
+ * how much actually fits the cell.
+ */
+internal fun ellipsizeTitle(title: String, maxChars: Int): String {
+    if (maxChars <= 1 || title.length <= maxChars) return title
+    return title.take(maxChars - 1).trimEnd() + "…"
 }
 
 /**

--- a/app/src/main/kotlin/org/onekash/kashcal/widget/MonthWidgetSpanLayout.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/widget/MonthWidgetSpanLayout.kt
@@ -159,11 +159,12 @@ internal fun computeMonthWidgetWeekRender(
         }
     }
 
-    // 4. Drop trailing all-empty rows so short weeks stay compact.
+    // 4. Drop trailing all-empty rows so short weeks stay compact. A week with no events at
+    //    all collapses to zero rows — the caller renders nothing below the day numbers.
     val rows = grid.map { it.toList() }
     var last = rows.size - 1
-    while (last > 0 && rows[last].all { it === MonthWidgetSlot.Empty }) last--
-    return MonthWidgetWeekRender(slots = rows.subList(0, last + 1))
+    while (last >= 0 && rows[last].all { it === MonthWidgetSlot.Empty }) last--
+    return MonthWidgetWeekRender(slots = if (last < 0) emptyList() else rows.subList(0, last + 1))
 }
 
 /** All-day busy = 0; all-day free = 1; timed = 2. Lower sorts first — same as the app. */

--- a/app/src/main/kotlin/org/onekash/kashcal/widget/MonthWidgetSpanLayout.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/widget/MonthWidgetSpanLayout.kt
@@ -1,0 +1,174 @@
+package org.onekash.kashcal.widget
+
+import org.onekash.kashcal.widget.WidgetDataRepository.WidgetEvent
+
+/**
+ * Week-slot layout for the month widget's titles mode.
+ *
+ * A pure port of the in-app month view's [org.onekash.kashcal.ui.screens.monthfull.computeMonthFullWeekRender]
+ * onto [WidgetEvent]: multi-day events become continuous bars that span their day columns in
+ * a shared lane grid, single-day events fill the remaining per-cell slots, and whatever does
+ * not fit collapses into a per-cell "+n more" overflow slot.
+ *
+ * Lanes win over cell events: when a day column is fully occupied by spanning bars, that
+ * day's single-day events are dropped silently (they remain reachable by tapping the day) —
+ * the same policy the in-app month view applies.
+ */
+
+/** A multi-day event bar covering [startCol]..[endCol] of a week row. */
+internal data class MonthWidgetSpan(
+    val event: WidgetEvent,
+    val startCol: Int,
+    val endCol: Int,
+    /** Continues from the previous week — the bar's leading edge stays flush (no cap, no title). */
+    val leftFlush: Boolean,
+    /** Continues into the next week — the bar's trailing edge stays flush (no cap). */
+    val rightFlush: Boolean,
+)
+
+/** One cell's worth of content inside a slot row. */
+internal sealed interface MonthWidgetSlot {
+    /** Nothing here — the cell background shows through. */
+    data object Empty : MonthWidgetSlot
+
+    /** Part of a multi-day bar; a run of consecutive segments forms one continuous bar. */
+    data class BarSegment(val span: MonthWidgetSpan) : MonthWidgetSlot
+
+    /** A single-day event snippet (timed stripe or all-day chip). */
+    data class CellEvent(val event: WidgetEvent) : MonthWidgetSlot
+
+    /** "+n more" marker for events that did not fit this cell. */
+    data class Overflow(val count: Int) : MonthWidgetSlot
+}
+
+/**
+ * The slot rows of one week: [slots] is indexed [slotIndex][column] with 7 columns.
+ * Only non-empty rows are returned.
+ */
+internal data class MonthWidgetWeekRender(
+    val slots: List<List<MonthWidgetSlot>>
+)
+
+/**
+ * Compute the slot rows for one week of the month grid in titles mode.
+ *
+ * @param weekDayCodes the 7 day codes (YYYYMMDD) of the week, in column order
+ * @param eventsByDay events grouped by day code (as fetched for the whole grid range)
+ * @param maxSlots maximum number of slot rows below the day-number row; what does not fit
+ *   collapses into [MonthWidgetSlot.Overflow]
+ */
+internal fun computeMonthWidgetWeekRender(
+    weekDayCodes: List<Int>,
+    eventsByDay: Map<Int, List<WidgetEvent>>,
+    maxSlots: Int
+): MonthWidgetWeekRender {
+    require(weekDayCodes.size == 7) { "weekDayCodes must have 7 entries" }
+    if (maxSlots <= 0) return MonthWidgetWeekRender(emptyList())
+
+    val weekStart = weekDayCodes.first()
+    val weekEnd = weekDayCodes.last()
+
+    // 1. Collect the week's multi-day events, deduped across day buckets. Only this week's
+    //    own day buckets are scanned: the fetch range covers the whole month grid, and an
+    //    event that never touches this week must never leak into the row as a flush bar.
+    val seen = LinkedHashMap<String, WidgetEvent>()
+    for (dayCode in weekDayCodes) {
+        for (e in eventsByDay[dayCode].orEmpty()) {
+            if (!e.isMultiDay) continue
+            seen.putIfAbsent(e.spanKey, e)
+        }
+    }
+
+    // 2. Clamp every span to the week. The guards make the columns total: an event that
+    //    overlaps the week always lands on a valid [0..6] range — startCol/endCol are
+    //    derived from the same clamped dates, so they can never disagree with the guard.
+    val spans = seen.values.mapNotNull { e ->
+        if (e.endDay < weekStart || e.startDay > weekEnd) return@mapNotNull null
+        val leftFlush = e.startDay < weekStart
+        val rightFlush = e.endDay > weekEnd
+        val startCol = if (leftFlush) 0 else weekDayCodes.indexOf(e.startDay)
+        val endCol = if (rightFlush) 6 else weekDayCodes.indexOf(e.endDay)
+        // With the overlap guard above, indexOf can only miss when the week list itself is
+        // inconsistent — drop rather than draw a bar from a bogus anchor.
+        if (startCol < 0 || endCol < 0 || startCol > endCol) return@mapNotNull null
+        MonthWidgetSpan(
+            event = e,
+            startCol = startCol,
+            endCol = endCol,
+            leftFlush = leftFlush,
+            rightFlush = rightFlush,
+        )
+    }
+
+    // 2. Place spans into lanes: earliest start first, longest first on ties, so short
+    //    spans can share a freed lane behind a long one.
+    val lanes = mutableListOf<MutableList<MonthWidgetSpan>>()
+    var laneOverflow = 0
+    for (span in spans.sortedWith(compareBy({ it.startCol }, { -(it.endCol - it.startCol) }))) {
+        val laneIndex = lanes.indexOfFirst { lane -> lane.last().endCol < span.startCol }
+        when {
+            laneIndex >= 0 -> lanes[laneIndex].add(span)
+            lanes.size < maxSlots -> lanes.add(mutableListOf(span))
+            else -> laneOverflow++
+        }
+    }
+
+    // 3. Bars occupy their lane (slot) columns; cell events fill what remains.
+    val grid: Array<Array<MonthWidgetSlot>> = Array(maxSlots) { Array(7) { MonthWidgetSlot.Empty } }
+    for ((laneIndex, lane) in lanes.withIndex()) {
+        for (span in lane) {
+            for (col in span.startCol..span.endCol) {
+                grid[laneIndex][col] = MonthWidgetSlot.BarSegment(span)
+            }
+        }
+    }
+
+    for (col in 0..6) {
+        val cellEvents = eventsByDay[weekDayCodes[col]].orEmpty()
+            .filter { !it.isMultiDay }
+            .sortedWith(compareBy<WidgetEvent> { eventOrderRank(it) }.thenBy { it.startTs })
+
+        val freeSlots = (0 until maxSlots).filter { grid[it][col] === MonthWidgetSlot.Empty }
+        when {
+            cellEvents.size <= freeSlots.size -> {
+                for ((i, event) in cellEvents.withIndex()) {
+                    grid[freeSlots[i]][col] = MonthWidgetSlot.CellEvent(event)
+                }
+            }
+            freeSlots.isEmpty() -> {
+                // Column fully bar-occupied: cell events drop silently (lanes-win policy).
+            }
+            else -> {
+                // More events than free slots: show what fits, collapse the rest into a
+                // "+n" marker in the LAST free slot — matching the in-app month view. With
+                // exactly one free slot the single visible event yields to the marker, so
+                // the day still reports its real count instead of going silently blank.
+                val visibleCount = (freeSlots.size - 1).coerceAtLeast(0)
+                for (i in 0 until visibleCount) {
+                    grid[freeSlots[i]][col] = MonthWidgetSlot.CellEvent(cellEvents[i])
+                }
+                // Lane-overflowed spans belong to this cell's hidden remainder too, but only
+                // in the cell where the span would have started — counting them everywhere
+                // would inflate every column of the week.
+                val hiddenSpansHere = if (laneOverflow > 0) {
+                    spans.count { it.startCol == col && lanes.none { lane -> lane.contains(it) } }
+                } else 0
+                grid[freeSlots[freeSlots.size - 1]][col] =
+                    MonthWidgetSlot.Overflow(cellEvents.size - visibleCount + hiddenSpansHere)
+            }
+        }
+    }
+
+    // 4. Drop trailing all-empty rows so short weeks stay compact.
+    val rows = grid.map { it.toList() }
+    var last = rows.size - 1
+    while (last > 0 && rows[last].all { it === MonthWidgetSlot.Empty }) last--
+    return MonthWidgetWeekRender(slots = rows.subList(0, last + 1))
+}
+
+/** All-day busy = 0; all-day free = 1; timed = 2. Lower sorts first — same as the app. */
+private fun eventOrderRank(event: WidgetEvent): Int = when {
+    event.isAllDay && !event.isFree -> 0
+    event.isAllDay && event.isFree -> 1
+    else -> 2
+}

--- a/app/src/main/kotlin/org/onekash/kashcal/widget/WidgetDataRepository.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/widget/WidgetDataRepository.kt
@@ -38,8 +38,16 @@ class WidgetDataRepository @Inject constructor(
         val isPast: Boolean,
         val isDeviceEvent: Boolean,
         val startDay: Int,
-        val isCancelled: Boolean = false
-    )
+        val isCancelled: Boolean = false,
+        val isFree: Boolean = false,
+        val endDay: Int = startDay
+    ) {
+        /** Multi-day events span more than one day cell and render as continuous bars. */
+        val isMultiDay: Boolean get() = startDay != endDay
+
+        /** Stable identity across the day buckets the event appears in (for span dedup). */
+        val spanKey: String get() = "$eventId:$occurrenceStartTs"
+    }
 
     /**
      * Get today's events for the widget.
@@ -131,7 +139,9 @@ class WidgetDataRepository @Inject constructor(
             isPast = DateTimeUtils.isEventPast(displayEvent.endTs, displayEvent.endDay, displayEvent.isAllDay),
             isDeviceEvent = displayEvent is DisplayEvent.Device,
             startDay = displayEvent.startDay,
-            isCancelled = displayEvent.isCancelled
+            isCancelled = displayEvent.isCancelled,
+            isFree = displayEvent.isFree,
+            endDay = displayEvent.endDay
         )
     }
 

--- a/app/src/main/kotlin/org/onekash/kashcal/widget/WidgetPreviewContent.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/widget/WidgetPreviewContent.kt
@@ -95,7 +95,10 @@ internal fun MonthPreviewContent(context: Context) {
             monthOffset = 0,
             targetYear = grid.year,
             targetMonth0 = grid.month,
-            firstDayOfWeek = WidgetPreviewData.LOCALE_FIRST_DAY_OF_WEEK
+            firstDayOfWeek = WidgetPreviewData.LOCALE_FIRST_DAY_OF_WEEK,
+            // Show the titles style: it is the richer day-cell look and matches what the
+            // in-app month view advertises.
+            showEventTitles = true
         )
     }
 }

--- a/app/src/main/kotlin/org/onekash/kashcal/widget/WidgetStateFetchers.kt
+++ b/app/src/main/kotlin/org/onekash/kashcal/widget/WidgetStateFetchers.kt
@@ -5,6 +5,7 @@ import android.text.format.DateFormat
 import android.util.Log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeoutOrNull
 import org.onekash.kashcal.data.preferences.KashCalDataStore
 import org.onekash.kashcal.util.DateTimeUtils
 
@@ -18,6 +19,24 @@ import org.onekash.kashcal.util.DateTimeUtils
  */
 
 private const val TAG = "WidgetStateFetchers"
+
+/**
+ * Upper bound for a widget's data fetch. A fetch that exceeds this is abandoned and the
+ * caller falls back to its empty/error state — the widget's Glance session must never be
+ * parked inside a fetch for minutes, because actionRunCallback taps (month navigation,
+ * refresh) are processed on that same session and would appear frozen. The prime suspect
+ * for multi-minute stalls is a CalendarProvider Instances query while the system's sync
+ * adapter holds the provider (contentResolver.query has no timeout of its own).
+ */
+internal const val WIDGET_FETCH_TIMEOUT_MS = 10_000L
+
+/**
+ * Thrown when a widget data fetch exceeds [WIDGET_FETCH_TIMEOUT_MS]. Distinct from
+ * [kotlinx.coroutines.TimeoutCancellationException] (a [CancellationException] subclass)
+ * so the generic `catch (e: Exception)` fallback below handles it — a fetch timeout must
+ * degrade to the widget's empty/error state, not cancel the session's producer coroutine.
+ */
+internal class WidgetFetchTimeoutException(message: String) : Exception(message)
 
 /**
  * Sealed state for [UpcomingWidget]. The scaffold composable branches on this to render
@@ -50,7 +69,9 @@ internal suspend fun fetchUpcomingState(
             nowMs = System.currentTimeMillis(),
             horizonDays = horizonDays
         )
-        val eventsByDay = repository.getEventsInRange(startDayCode, endDayCode)
+        val eventsByDay = withTimeoutOrNull(WIDGET_FETCH_TIMEOUT_MS) {
+            repository.getEventsInRange(startDayCode, endDayCode)
+        } ?: throw WidgetFetchTimeoutException("getEventsInRange exceeded ${WIDGET_FETCH_TIMEOUT_MS}ms")
         val showEventEmojis = dataStore.showEventEmojis.first()
         val timeFormatPref = dataStore.getTimeFormat()
         val is24Hour = DateFormat.is24HourFormat(context)
@@ -102,7 +123,9 @@ internal suspend fun fetchAgendaData(
     context: Context
 ): AgendaData {
     return try {
-        val events = repository.getTodayEvents()
+        val events = withTimeoutOrNull(WIDGET_FETCH_TIMEOUT_MS) {
+            repository.getTodayEvents()
+        } ?: throw WidgetFetchTimeoutException("getTodayEvents exceeded ${WIDGET_FETCH_TIMEOUT_MS}ms")
         val showEventEmojis = dataStore.showEventEmojis.first()
         val maxEventsPerDay = dataStore.widgetMaxEventsPerDay.first()
         val timeFormatPref = dataStore.getTimeFormat()
@@ -144,7 +167,9 @@ internal suspend fun fetchWeekData(
     context: Context
 ): WeekData {
     return try {
-        val weekEvents = repository.getWeekEvents()
+        val weekEvents = withTimeoutOrNull(WIDGET_FETCH_TIMEOUT_MS) {
+            repository.getWeekEvents()
+        } ?: throw WidgetFetchTimeoutException("getWeekEvents exceeded ${WIDGET_FETCH_TIMEOUT_MS}ms")
         val showEventEmojis = dataStore.showEventEmojis.first()
         val maxEventsPerDay = dataStore.widgetMaxEventsPerDay.first()
         val timeFormatPref = dataStore.getTimeFormat()
@@ -177,7 +202,12 @@ internal suspend fun fetchMonthEvents(
     endDayCode: Int
 ): Map<Int, List<WidgetDataRepository.WidgetEvent>> {
     return try {
-        repository.getEventsInRange(startDayCode, endDayCode)
+        withTimeoutOrNull(WIDGET_FETCH_TIMEOUT_MS) {
+            repository.getEventsInRange(startDayCode, endDayCode)
+        } ?: run {
+            Log.w(TAG, "fetchMonthEvents timed out after ${WIDGET_FETCH_TIMEOUT_MS}ms; keeping previous content")
+            emptyMap()
+        }
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -575,6 +575,8 @@
     <string name="settings_widget_event_limit_hint">Maximale Anzahl Termine pro Tag in Widgets</string>
     <string name="settings_detailed_widget_rows">Detaillierte Widget-Zeilen</string>
     <string name="settings_detailed_widget_rows_info">Kompakt in einer Zeile oder detailliert in zwei Zeilen mit Endzeit.</string>
+    <string name="settings_month_widget_event_titles">Termintitel im Monats-Widget</string>
+    <string name="settings_month_widget_event_titles_info">Termine in den Tageszellen des Monats-Widgets mit Titel statt als Farbpunkte anzeigen – wie die Monatsansicht in der App.</string>
     <string name="settings_sync_lookback">Sync-Rückblick</string>
     <string name="settings_sync_lookback_hint">Wie weit zurück Termine synchronisiert werden</string>
     <string name="settings_not_set">Nicht festgelegt</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -853,6 +853,10 @@
     <string name="settings_detailed_widget_rows">Detailed widget rows</string>
     <!-- Info tooltip explaining the Detailed widget rows toggle -->
     <string name="settings_detailed_widget_rows_info">Compact single line, or detailed two lines with end time.</string>
+    <!-- "Widget" = Android home screen widget. Toggle: month widget day cells show event titles instead of color dots. -->
+    <string name="settings_month_widget_event_titles">Month widget event titles</string>
+    <!-- Info tooltip explaining the Month widget event titles toggle -->
+    <string name="settings_month_widget_event_titles_info">Show event titles in the month widget’s day cells instead of color dots, like the month view in the app.</string>
     <!-- "Lookback" = how far back in time to sync -->
     <string name="settings_sync_lookback">Sync lookback</string>
     <!-- Subtitle hint under the Sync lookback row -->

--- a/app/src/test/kotlin/org/onekash/kashcal/domain/backup/ExportablePreferencesTest.kt
+++ b/app/src/test/kotlin/org/onekash/kashcal/domain/backup/ExportablePreferencesTest.kt
@@ -12,8 +12,8 @@ import org.onekash.kashcal.data.preferences.PreferencesKeys
 class ExportablePreferencesTest {
 
     @Test
-    fun `allow list contains exactly 41 keys`() {
-        assertEquals(41, ExportablePreferences.KEYS.size)
+    fun `allow list contains exactly 42 keys`() {
+        assertEquals(42, ExportablePreferences.KEYS.size)
     }
 
     @Test
@@ -199,6 +199,18 @@ class ExportablePreferencesTest {
                 allowedNames.contains(key.name),
             )
         }
+    }
+
+    @Test
+    fun `MONTH_WIDGET_EVENT_TITLES is in the allow-list as a persistent widget display choice`() {
+        assertTrue(
+            "MONTH_WIDGET_EVENT_TITLES must be in the allow-list",
+            ExportablePreferences.KEYS.any { it.name == PreferencesKeys.MONTH_WIDGET_EVENT_TITLES.name },
+        )
+        assertFalse(
+            "MONTH_WIDGET_EVENT_TITLES must not be in EXCLUDED_KEY_NAMES",
+            ExportablePreferences.EXCLUDED_KEY_NAMES.contains(PreferencesKeys.MONTH_WIDGET_EVENT_TITLES.name),
+        )
     }
 
     @Test

--- a/app/src/test/kotlin/org/onekash/kashcal/ui/screens/AccountSettingsScreenViewModelWiringTest.kt
+++ b/app/src/test/kotlin/org/onekash/kashcal/ui/screens/AccountSettingsScreenViewModelWiringTest.kt
@@ -121,6 +121,7 @@ class AccountSettingsScreenViewModelWiringTest {
         every { vm.showWeekNumbers } returns MutableStateFlow(weekNumbers)
         every { vm.widgetMaxEventsPerDay } returns MutableStateFlow(widget)
         every { vm.widgetDetailedRows } returns MutableStateFlow(false)
+        every { vm.monthWidgetEventTitles } returns MutableStateFlow(false)
         every { vm.syncLookbackDays } returns MutableStateFlow(KashCalDataStore.DEFAULT_SYNC_PAST_DAYS)
         every { vm.isSearchActive } returns MutableStateFlow(false)
         every { vm.searchQuery } returns MutableStateFlow("")

--- a/app/src/test/kotlin/org/onekash/kashcal/widget/MonthWidgetContentTest.kt
+++ b/app/src/test/kotlin/org/onekash/kashcal/widget/MonthWidgetContentTest.kt
@@ -275,9 +275,10 @@ class MonthWidgetContentTest {
 
     @Test
     fun `ellipsizeTitle trims trailing whitespace before the ellipsis`() {
-        // "Project X" at 8 chars: take(7) = "Project" + "…" — no dangling space
-        assertEquals("Projec…", ellipsizeTitle("Project X", 8))
-        assertEquals("Standup…", ellipsizeTitle("Standup Meeting", 8))
+        // take(7) of "Project X" is "Project" (no trailing space), so the ellipsis
+        // attaches directly; "Team sync" takes "Team sy" -> trimEnd -> "Team sy…"
+        assertEquals("Project…", ellipsizeTitle("Project X", 8))
+        assertEquals("Team sy…", ellipsizeTitle("Team sync", 8))
     }
 
     @Test

--- a/app/src/test/kotlin/org/onekash/kashcal/widget/MonthWidgetContentTest.kt
+++ b/app/src/test/kotlin/org/onekash/kashcal/widget/MonthWidgetContentTest.kt
@@ -224,6 +224,67 @@ class MonthWidgetContentTest {
         assertEquals("March 15, no events", desc)
     }
 
+    // ==================== maxEventRows ====================
+
+    @Test
+    fun `maxEventRows returns 0 when not even one row fits below the day number`() {
+        // 18 (number) + 13 (one row) = 31dp minimum
+        assertEquals(0, maxEventRows(30f))
+    }
+
+    @Test
+    fun `maxEventRows fits exactly one row at the minimum height`() {
+        assertEquals(1, maxEventRows(31f))
+    }
+
+    @Test
+    fun `maxEventRows fits two rows at the standard widget cell height`() {
+        // Standard widget: 304dp tall, 5 weeks -> ~48dp cell. 18 + 13 + 1 + 13 = 45dp.
+        assertEquals(2, maxEventRows(48.2f))
+    }
+
+    @Test
+    fun `maxEventRows caps at MAX_EVENT_ROWS on tall cells`() {
+        assertEquals(MAX_EVENT_ROWS, maxEventRows(200f))
+    }
+
+    // ==================== maxTitleChars ====================
+
+    @Test
+    fun `maxTitleChars estimates characters from cell width`() {
+        // (50 - 8) / 6 = 7
+        assertEquals(7, maxTitleChars(50f))
+    }
+
+    @Test
+    fun `maxTitleChars never drops below 4`() {
+        assertEquals(4, maxTitleChars(20f))
+    }
+
+    // ==================== ellipsizeTitle ====================
+
+    @Test
+    fun `ellipsizeTitle keeps titles that fit`() {
+        assertEquals("Gym", ellipsizeTitle("Gym", 7))
+    }
+
+    @Test
+    fun `ellipsizeTitle truncates with ellipsis`() {
+        assertEquals("Desi…", ellipsizeTitle("Design Review", 5))
+    }
+
+    @Test
+    fun `ellipsizeTitle trims trailing whitespace before the ellipsis`() {
+        // "Project X" at 8 chars: take(7) = "Project" + "…" — no dangling space
+        assertEquals("Projec…", ellipsizeTitle("Project X", 8))
+        assertEquals("Standup…", ellipsizeTitle("Standup Meeting", 8))
+    }
+
+    @Test
+    fun `ellipsizeTitle returns the title untouched for degenerate budgets`() {
+        assertEquals("Gym", ellipsizeTitle("Gym", 0))
+    }
+
     private fun createWidgetEvent(
         calendarColor: Int = 0xFF2196F3.toInt()
     ): WidgetDataRepository.WidgetEvent {

--- a/app/src/test/kotlin/org/onekash/kashcal/widget/MonthWidgetSpanLayoutTest.kt
+++ b/app/src/test/kotlin/org/onekash/kashcal/widget/MonthWidgetSpanLayoutTest.kt
@@ -1,0 +1,277 @@
+package org.onekash.kashcal.widget
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.onekash.kashcal.widget.WidgetDataRepository.WidgetEvent
+
+/**
+ * Pure-logic tests for [computeMonthWidgetWeekRender] — the week slot layout behind the
+ * month widget's titles mode (multi-day bars, per-cell snippets, overflow).
+ *
+ * Week under test: Monday 2026-08-03 .. Sunday 2026-08-09 (day codes 20260803..20260809).
+ */
+class MonthWidgetSpanLayoutTest {
+
+    private val week = (3..9).map { 20260800 + it }
+
+    // ==================== Basics ====================
+
+    @Test
+    fun `no events yields no slot rows`() {
+        val render = computeMonthWidgetWeekRender(week, emptyMap(), maxSlots = 3)
+        assertTrue(render.slots.isEmpty())
+    }
+
+    @Test
+    fun `zero slot budget yields no rows`() {
+        val events = mapOf(week[0] to listOf(timed(day = 3)))
+        val render = computeMonthWidgetWeekRender(week, events, maxSlots = 0)
+        assertTrue(render.slots.isEmpty())
+    }
+
+    @Test
+    fun `single-day events land in their own column`() {
+        val events = mapOf(
+            week[0] to listOf(timed(day = 3)),
+            week[4] to listOf(timed(day = 7), timed(day = 7, title = "Second"))
+        )
+        val render = computeMonthWidgetWeekRender(week, events, maxSlots = 3)
+        assertEquals(2, render.slots.size)
+        assertTrue(render.slots[0][0] is MonthWidgetSlot.CellEvent)
+        assertEquals(MonthWidgetSlot.Empty, render.slots[1][0])
+        assertTrue(render.slots[0][4] is MonthWidgetSlot.CellEvent)
+        assertTrue(render.slots[1][4] is MonthWidgetSlot.CellEvent)
+    }
+
+    // ==================== Multi-day spans ====================
+
+    @Test
+    fun `multi-day event spans its columns as one run of bar segments`() {
+        val span = multiDay(startDay = 20260804, endDay = 20260806)
+        val render = computeMonthWidgetWeekRender(week, mapOf(week[1] to listOf(span)), maxSlots = 3)
+        assertEquals(1, render.slots.size)
+        val row = render.slots[0]
+        assertEquals(MonthWidgetSlot.Empty, row[0])
+        for (col in 1..3) {
+            val segment = row[col] as? MonthWidgetSlot.BarSegment
+                ?: error("col $col should be a BarSegment")
+            assertEquals(span.eventId, segment.span.event.eventId)
+        }
+        assertEquals(MonthWidgetSlot.Empty, row[4])
+    }
+
+    @Test
+    fun `span continuing from the previous week starts flush at column 0`() {
+        val span = multiDay(startDay = 20260730, endDay = 20260805)
+        val render = computeMonthWidgetWeekRender(week, mapOf(week[2] to listOf(span)), maxSlots = 3)
+        val segment = render.slots[0][0] as MonthWidgetSlot.BarSegment
+        assertTrue(segment.span.leftFlush)
+        assertTrue(!segment.span.rightFlush)
+        assertEquals(0, segment.span.startCol)
+        assertEquals(2, segment.span.endCol)
+    }
+
+    @Test
+    fun `span continuing into the next week ends flush at column 6`() {
+        val span = multiDay(startDay = 20260807, endDay = 20260812)
+        val render = computeMonthWidgetWeekRender(week, mapOf(week[4] to listOf(span)), maxSlots = 3)
+        val segment = render.slots[0][6] as MonthWidgetSlot.BarSegment
+        assertTrue(!segment.span.leftFlush)
+        assertTrue(segment.span.rightFlush)
+        assertEquals(4, segment.span.startCol)
+        assertEquals(6, segment.span.endCol)
+    }
+
+    @Test
+    fun `overlapping spans occupy separate lanes`() {
+        val a = multiDay(startDay = 20260804, endDay = 20260806, title = "A")
+        val b = multiDay(startDay = 20260805, endDay = 20260807, title = "B")
+        val render = computeMonthWidgetWeekRender(week, mapOf(week[1] to listOf(a, b)), maxSlots = 3)
+        assertEquals(2, render.slots.size)
+        // A (earlier start) takes lane 0, B lane 1 — they overlap on columns 2..3.
+        val aSeg = render.slots[0][2] as MonthWidgetSlot.BarSegment
+        val bSeg = render.slots[1][2] as MonthWidgetSlot.BarSegment
+        assertEquals("A", aSeg.span.event.title)
+        assertEquals("B", bSeg.span.event.title)
+    }
+
+    @Test
+    fun `non-overlapping spans share one lane`() {
+        val a = multiDay(startDay = 20260803, endDay = 20260804, title = "A")
+        val b = multiDay(startDay = 20260806, endDay = 20260808, title = "B")
+        val render = computeMonthWidgetWeekRender(week, mapOf(week[0] to listOf(a), week[3] to listOf(b)), maxSlots = 3)
+        assertEquals(1, render.slots.size)
+        assertEquals("A", (render.slots[0][0] as MonthWidgetSlot.BarSegment).span.event.title)
+        assertEquals("B", (render.slots[0][3] as MonthWidgetSlot.BarSegment).span.event.title)
+    }
+
+    @Test
+    fun `span is deduplicated across the day buckets it appears in`() {
+        val span = multiDay(startDay = 20260804, endDay = 20260806)
+        // The repository groups a multi-day event into EVERY day it touches — the layout
+        // must still render exactly one bar for it.
+        val events = mapOf(
+            week[1] to listOf(span),
+            week[2] to listOf(span),
+            week[3] to listOf(span)
+        )
+        val render = computeMonthWidgetWeekRender(week, events, maxSlots = 3)
+        assertEquals(1, render.slots.size)
+        val segments = render.slots[0].filterIsInstance<MonthWidgetSlot.BarSegment>()
+        assertEquals("one bar run across Tue..Thu", 3, segments.size)
+        assertEquals("all segments belong to the same event", 1, segments.map { it.span.event.spanKey }.distinct().size)
+    }
+
+    // ==================== Overflow ====================
+
+    @Test
+    fun `cell events beyond the slot budget collapse into an overflow slot`() {
+        val events = mapOf(week[2] to List(4) { timed(day = 5, title = "E$it") })
+        val render = computeMonthWidgetWeekRender(week, events, maxSlots = 3)
+        assertEquals(3, render.slots.size)
+        // Last slot of the column: 2 visible events + "+2".
+        assertTrue(render.slots[0][2] is MonthWidgetSlot.CellEvent)
+        assertTrue(render.slots[1][2] is MonthWidgetSlot.CellEvent)
+        val overflow = render.slots[2][2] as MonthWidgetSlot.Overflow
+        assertEquals(2, overflow.count)
+    }
+
+    @Test
+    fun `overflow counts only the hidden events`() {
+        val events = mapOf(week[2] to List(3) { timed(day = 5, title = "E$it") })
+        val render = computeMonthWidgetWeekRender(week, events, maxSlots = 3)
+        assertEquals(3, render.slots.size)
+        assertTrue(render.slots.all { it[2] is MonthWidgetSlot.CellEvent })
+    }
+
+    @Test
+    fun `lanes win over cell events when a column is fully bar-occupied`() {
+        // Two bars cover the whole week in lanes 0 and 1; with maxSlots = 2 the column has
+        // no free slot left, so its single-day event drops without an overflow marker.
+        val a = multiDay(startDay = 20260803, endDay = 20260809, title = "A")
+        val b = multiDay(startDay = 20260803, endDay = 20260809, title = "B")
+        val events = mapOf(
+            week[0] to listOf(a, b, timed(day = 3))
+        )
+        val render = computeMonthWidgetWeekRender(week, events, maxSlots = 2)
+        assertEquals(2, render.slots.size)
+        assertTrue(render.slots.all { row -> row.all { it is MonthWidgetSlot.BarSegment } })
+    }
+
+    // ==================== Cross-month spans ====================
+
+    @Test
+    fun `span ending the day before this week renders no bar`() {
+        // Event 2026-07-31 .. 2026-08-02 ends the day BEFORE this week's Monday (08-03).
+        // The grid fetch range starts at the grid's first cell (here 07-27), so the event
+        // IS present in the month data — it must not leak into this week as a flush bar
+        // "between" Friday and Saturday that shoves the week's real content one lane down.
+        val span = multiDay(startDay = 20260731, endDay = 20260802)
+        val events = mapOf(20260731 to listOf(span), 20260801 to listOf(span), 20260802 to listOf(span))
+        val render = computeMonthWidgetWeekRender(week, events, maxSlots = 3)
+        assertTrue(render.slots.all { row -> row.none { it is MonthWidgetSlot.BarSegment } })
+    }
+
+    @Test
+    fun `span starting the day after this week renders no bar`() {
+        // Event 2026-08-10 .. 2026-08-12 starts the day AFTER this week's Sunday (08-09).
+        val span = multiDay(startDay = 20260810, endDay = 20260812)
+        val events = mapOf(20260810 to listOf(span), 20260811 to listOf(span), 20260812 to listOf(span))
+        val render = computeMonthWidgetWeekRender(week, events, maxSlots = 3)
+        assertTrue(render.slots.all { row -> row.none { it is MonthWidgetSlot.BarSegment } })
+    }
+
+    @Test
+    fun `span from the previous month ending inside this week renders with a flush left edge only`() {
+        // Event 2026-07-31 .. 2026-08-04: starts before the week, ends on Tuesday (col 1).
+        val span = multiDay(startDay = 20260731, endDay = 20260804)
+        val events = mapOf(week[0] to listOf(span), week[1] to listOf(span))
+        val render = computeMonthWidgetWeekRender(week, events, maxSlots = 3)
+        val row = render.slots[0]
+        val first = row[0] as MonthWidgetSlot.BarSegment
+        val second = row[1] as MonthWidgetSlot.BarSegment
+        assertTrue(first.span.leftFlush)
+        assertTrue(!second.span.rightFlush)
+        assertEquals(0, first.span.startCol)
+        assertEquals(1, second.span.endCol)
+        assertEquals(MonthWidgetSlot.Empty, row[2])
+    }
+
+    @Test
+    fun `span starting this week and ending next month renders with a flush right edge only`() {
+        // Event 2026-08-08 .. 2026-08-11: starts Saturday (col 5), runs past week end.
+        val span = multiDay(startDay = 20260808, endDay = 20260811)
+        val events = mapOf(week[5] to listOf(span), week[6] to listOf(span))
+        val render = computeMonthWidgetWeekRender(week, events, maxSlots = 3)
+        val row = render.slots[0]
+        assertEquals(MonthWidgetSlot.Empty, row[4])
+        val fifth = row[5] as MonthWidgetSlot.BarSegment
+        val sixth = row[6] as MonthWidgetSlot.BarSegment
+        assertTrue(!fifth.span.leftFlush)
+        assertTrue(sixth.span.rightFlush)
+        assertEquals(5, fifth.span.startCol)
+        assertEquals(6, sixth.span.endCol)
+    }
+
+    // ==================== Sorting ====================
+
+    @Test
+    fun `all-day busy sorts before all-day free, timed last`() {
+        val events = mapOf(
+            week[0] to listOf(
+                timed(day = 3, title = "Timed"),
+                allDay(day = 3, title = "Free", isFree = true),
+                allDay(day = 3, title = "Busy")
+            )
+        )
+        val render = computeMonthWidgetWeekRender(week, events, maxSlots = 3)
+        val titles = render.slots.map { (it[0] as MonthWidgetSlot.CellEvent).event.title }
+        assertEquals(listOf("Busy", "Free", "Timed"), titles)
+    }
+
+    // ==================== Helpers ====================
+
+    private fun timed(day: Int, title: String = "Timed") = WidgetEvent(
+        eventId = title.hashCode().toLong(),
+        occurrenceStartTs = day * 1000L,
+        title = title,
+        startTs = day * 1000L,
+        endTs = day * 1000L + 3_600_000L,
+        isAllDay = false,
+        calendarColor = 0xFF2196F3.toInt(),
+        isPast = false,
+        isDeviceEvent = false,
+        startDay = 20260800 + day,
+        endDay = 20260800 + day
+    )
+
+    private fun allDay(day: Int, title: String, isFree: Boolean = false) = WidgetEvent(
+        eventId = title.hashCode().toLong(),
+        occurrenceStartTs = day * 1000L,
+        title = title,
+        startTs = day * 1000L,
+        endTs = day * 1000L + 86_400_000L,
+        isAllDay = true,
+        calendarColor = 0xFF43A047.toInt(),
+        isPast = false,
+        isDeviceEvent = false,
+        startDay = 20260800 + day,
+        endDay = 20260800 + day,
+        isFree = isFree
+    )
+
+    private fun multiDay(startDay: Int, endDay: Int, title: String = "Trip") = WidgetEvent(
+        eventId = "$title$startDay".hashCode().toLong(),
+        occurrenceStartTs = startDay * 1000L,
+        title = title,
+        startTs = startDay * 1000L,
+        endTs = endDay * 1000L,
+        isAllDay = true,
+        calendarColor = 0xFF7E57C2.toInt(),
+        isPast = false,
+        isDeviceEvent = false,
+        startDay = startDay,
+        endDay = endDay
+    )
+}


### PR DESCRIPTION
## Description

Adds an Appearance-settings toggle (**Month widget event titles**) that switches the month widget's day cells from colored indicator dots to event title rows, mirroring the in-app month view:

- **Timed events** render as a color stripe plus title; **all-day events** as filled chips (free events tinted).
- **Multi-day events** span their day columns as one continuous bar, with the title at the bar's first segment of the week and flush edges when continuing across weeks.
- The **number of title rows adapts to the actual widget height** via `LocalSize` — grow the widget, see more titles. What doesn't fit collapses into a per-cell "+n more" marker (lanes-win policy for bar-occupied columns, same as the app).
- Bars and slot cells take **fixed widths** derived from the cell width, because Glance's `defaultWeight()` is always `weight(1f)` — there is no `weight(n)` to size a spanning bar with.
- The day number keeps its centered grid position in both modes; only the event rows below are left-aligned.

A second, self-contained commit bounds every widget data fetch to 10s (`withTimeoutOrNull`), so a stalled CalendarProvider/Room query can no longer park the Glance session and freeze the widget's nav actions (prev/next month, month title) for minutes while day-cell and "+" taps keep working.

`WidgetEvent` gains `endDay`/`isMultiDay`/`spanKey` for span identity. The preference travels in settings backups like the other widget display options, and the widget-picker preview shows the titles style. Strings in English and German; other locales fall back to English.

## Related Issue

(none — feature request, no tracking issue)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide
- [x] I have tested my changes locally
- [x] New and existing unit tests pass locally (`./gradlew test`)
- [x] The app builds successfully (`./gradlew assembleDebug`)

## AI Disclosure

- [ ] No AI assistance was used
- [x] AI assisted with: implementation, tests, and commit messages (pair-programmed with an AI coding assistant; all changes reviewed and verified by CI build + unit tests) - Kimi K3 with OpenCode.

## Screenshots
<img width="555" height="543" alt="grafik" src="https://github.com/user-attachments/assets/89eb2ca1-db8d-4bcd-b6ae-9a254f4790dd" />
<img width="555" height="543" alt="grafik" src="https://github.com/user-attachments/assets/4baca040-912b-4fe6-906c-2a0f611b4933" />
<img width="555" height="676" alt="grafik" src="https://github.com/user-attachments/assets/364d446a-eeeb-4e1c-b5c7-d39b01f48047" />
<img width="555" height="1139" alt="grafik" src="https://github.com/user-attachments/assets/26daa228-bf0a-48b2-9ffd-62a6bd818849" />
